### PR TITLE
refactor: remove WithHostNetworkAccess in favor of GetEndpointForNetwork

### DIFF
--- a/src/Microcks.Aspire/MicrocksBuilderExtensions.cs
+++ b/src/Microcks.Aspire/MicrocksBuilderExtensions.cs
@@ -165,26 +165,6 @@ public static class MicrocksBuilderExtensions
             : Path.GetFullPath(sourcePath, builder.ApplicationBuilder.AppHostDirectory);
     }
 
-
-    /// <summary>
-    /// Adds network access to the host machine from within the Microcks container.
-    /// </summary>
-    /// <param name="builder">The <see cref="IResourceBuilder{T}"/>.</param>
-    /// <param name="hostAlias">The hostname alias to use for the host machine. Defaults to 'host.docker.internal'.</param>
-    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    /// <remarks>
-    /// This allows the Microcks container to access services running on the host machine
-    /// using the specified hostname alias. 'host.docker.internal' is Docker's standard
-    /// hostname for accessing the host machine from containers.
-    /// </remarks>
-    public static IResourceBuilder<MicrocksResource> WithHostNetworkAccess(this IResourceBuilder<MicrocksResource> builder, string hostAlias = "host.docker.internal")
-    {
-        ArgumentNullException.ThrowIfNull(builder, nameof(builder));
-
-        return builder.WithContainerRuntimeArgs($"--add-host={hostAlias}:host-gateway");
-    }
-
-
     /// <summary>
     /// Configures the Microcks resource to include and enable an Async Minion.
     /// This allows Microcks to handle asynchronous messaging protocols.

--- a/tests/Microcks.Aspire.Tests/Fixtures/Mock/MicrocksMockingFixture.cs
+++ b/tests/Microcks.Aspire.Tests/Fixtures/Mock/MicrocksMockingFixture.cs
@@ -69,8 +69,6 @@ public sealed class MicrocksMockingFixture : IAsyncLifetime, IDisposable
             )
             .WithMainRemoteArtifacts("https://raw.githubusercontent.com/microcks/microcks/master/samples/APIPastry-openapi.yaml");
 
-        microcksBuilder.WithHostNetworkAccess("localhost");
-
         App = Builder.Build();
         await App.StartAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(false);


### PR DESCRIPTION
### Description

- Remove `WithHostNetworkAccess` in favor of `GetEndpointForNetwork` (Aspire 13.0+)
- Update README with the recommended approach for contract-testing with container-to-host communication
- Document `ASPIRE_ENABLE_CONTAINER_TUNNEL` experimental feature requirement

### Related issue(s)

See also [dotnet/aspire#6547](https://github.com/dotnet/aspire/issues/6547)
#57 