### PR TITLE
fix: publish test report on test failure

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -54,7 +54,7 @@ jobs:
     uses: ./.github/workflows/steps.publish-test-reporter.yml
     with:
       runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request' }}
+    if: ${{ always() && !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request' }}
     secrets: inherit
 
   nuget_publish:


### PR DESCRIPTION
### Description

Add always() condition to publish_test job to ensure test reports are published even when tests fail. This improves visibility into test failures during CI/CD runs.

### Related issue(s)

#77