### PR TITLE
fix: drop net9.0 target framework support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,6 @@ jobs:
         run: |
           curl -Lo $RUNNER_TEMP/sbom-tool https://github.com/microsoft/sbom-tool/releases/latest/download/sbom-tool-linux-x64
           chmod +x $RUNNER_TEMP/sbom-tool
-          # Generate SBOM for .NET 9.0 build output
-          $RUNNER_TEMP/sbom-tool generate -b ./src/Microcks.Aspire/obj/Release/net9.0 -bc . -pn Microcks.Aspire -pv ${{ github.event.inputs.version }} -ps Microcks -nsb https://microcks.io
-          cp ./src/Microcks.Aspire/obj/Release/net9.0/_manifest/spdx_2.2/manifest.spdx.json ./Microcks.Aspire-net9.0.spdx-sbom.json
           # Generate SBOM for .NET 10.0 build output
           $RUNNER_TEMP/sbom-tool generate -b ./src/Microcks.Aspire/obj/Release/net10.0 -bc . -pn Microcks.Aspire -pv ${{ github.event.inputs.version }} -ps Microcks -nsb https://microcks.io
           cp ./src/Microcks.Aspire/obj/Release/net10.0/_manifest/spdx_2.2/manifest.spdx.json ./Microcks.Aspire-net10.0.spdx-sbom.json

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 		<VersionSuffix>alpha</VersionSuffix>
 
 		<DefaultTargetFramework>net10.0</DefaultTargetFramework>
-		<TargetFrameworks>$(DefaultTargetFramework);net9.0</TargetFrameworks>
+		<TargetFrameworks>$(DefaultTargetFramework)</TargetFrameworks>
 
 		<Description>Microcks.Aspire for .NET</Description>
 		<Authors>Sébastien DEGODEZ</Authors>


### PR DESCRIPTION
## Description

Drop `net9.0` from `TargetFrameworks` in `Directory.Build.props` to fix the CI build failure.

Fixes #98

## Root Cause

The CI workflow only installs .NET 10 SDK (via `global.json`). When building for the `net9.0` target, the native `apphost` binary is missing, causing `MSB3030` error.

## Changes

- Remove `net9.0` from `TargetFrameworks` in `Directory.Build.props`, keeping only `net10.0`

## Rationale

- .NET 9 is an STS release reaching end of support in May 2026
- The project already defaults to `net10.0` (LTS)
- This unblocks all Dependabot PRs that currently fail on CI
